### PR TITLE
feat: change the way a user target its kubectl config context

### DIFF
--- a/cmd/cuebe/cmd/apply.go
+++ b/cmd/cuebe/cmd/apply.go
@@ -52,7 +52,7 @@ cuebe apply . main.enc.yaml
 # Extract Kubernetes context from <Build>.path.to.context
 cuebe apply -c .release.context .
 
-# Apply useing ne of your available kubectl config context
+# Apply using one of your available kubectl config context
 cuebe apply -c colima .
 
 # Perform a dry-run (do not persist changes)

--- a/cmd/cuebe/cmd/apply.go
+++ b/cmd/cuebe/cmd/apply.go
@@ -50,7 +50,10 @@ grouping them by instance if necessary.
 cuebe apply . main.enc.yaml
 
 # Extract Kubernetes context from <Build>.path.to.context
-cuebe apply -c $path.to.context .
+cuebe apply -c .release.context .
+
+# Apply useing ne of your available kubectl config context
+cuebe apply -c colima .
 
 # Perform a dry-run (do not persist changes)
 cuebe apply --dry-run .
@@ -76,8 +79,9 @@ func runApply(cmd *cobra.Command, args []string) {
 
 	// get kube config
 	ctx, err := cmd.Flags().GetString("cluster")
-	if strings.HasPrefix(ctx, "$") {
-		path := cue.ParsePath(strings.TrimLeft(ctx, "$"))
+	cobra.CheckErr(err)
+	if strings.HasPrefix(ctx, ".") {
+		path := cue.ParsePath(strings.TrimLeft(ctx, "."))
 		cobra.CheckErr(path.Err())
 		ctx, err = build.LookupPath(path).String()
 		cobra.CheckErr(err)

--- a/cmd/cuebe/cmd/delete.go
+++ b/cmd/cuebe/cmd/delete.go
@@ -43,6 +43,12 @@ cuebe delete .
 
 # Same but doing a dry-run
 cuebe delete --dry-run .
+
+# Delete using Kubernetes context from <Build>.path.to.context
+cuebe apply -c .release.context .
+
+# Delete using one of your available kubectl config context
+cuebe apply -c colima .
 `,
 		Run: runDelete,
 	}
@@ -65,8 +71,9 @@ func runDelete(cmd *cobra.Command, args []string) {
 
 	// get kube config
 	ctx, err := cmd.Flags().GetString("cluster")
-	if strings.HasPrefix(ctx, "$") {
-		path := cue.ParsePath(strings.TrimLeft(ctx, "$"))
+	cobra.CheckErr(err)
+	if strings.HasPrefix(ctx, ".") {
+		path := cue.ParsePath(strings.TrimLeft(ctx, "."))
 		cobra.CheckErr(path.Err())
 		ctx, err = build.LookupPath(path).String()
 		cobra.CheckErr(err)


### PR DESCRIPTION
Change the way a user will select the kubectl config context. Instead of `$` to tell the command to fetch the context from a path in the CUE release, the user will use `.`.