### PR TITLE
feat: eval subcommand

### DIFF
--- a/cmd/cuebe/cmd/apply.go
+++ b/cmd/cuebe/cmd/apply.go
@@ -70,7 +70,7 @@ cuebe apply --dry-run .
 }
 
 func runApply(cmd *cobra.Command, args []string) {
-	mfs, build, err := manifetsFrom(cmd)
+	mfs, build, err := manifestFrom(cmd)
 	cobra.CheckErr(err)
 
 	// group by Instances
@@ -111,7 +111,7 @@ func getK8sConfig(context string) (*utils.K8sConfig, error) {
 }
 
 // TODO move that in its own package
-func manifetsFrom(cmd *cobra.Command) ([]manifest.Manifest, cue.Value, error) {
+func manifestFrom(cmd *cobra.Command) ([]manifest.Manifest, cue.Value, error) {
 	opts := factory.GetBuildOpt(cmd)
 
 	// build

--- a/cmd/cuebe/cmd/apply.go
+++ b/cmd/cuebe/cmd/apply.go
@@ -123,6 +123,11 @@ func manifestFrom(cmd *cobra.Command) ([]manifest.Manifest, cue.Value, error) {
 		return nil, cue.Value{}, fmt.Errorf("could not build context: %w", err)
 	}
 
+	// Before trying to extract the manifests. We must ensure all values are concrete
+	if err = v.Validate(cue.Concrete(true)); err != nil {
+		return nil, v, fmt.Errorf("checking for concrete value and field definitions: %w", err)
+	}
+
 	// parse paths
 	paths := make([]cue.Path, 0, len(opts.Expressions))
 	for _, e := range opts.Expressions {

--- a/cmd/cuebe/cmd/delete.go
+++ b/cmd/cuebe/cmd/delete.go
@@ -63,7 +63,7 @@ cuebe apply -c colima .
 }
 
 func runDelete(cmd *cobra.Command, args []string) {
-	mfs, build, err := manifetsFrom(cmd)
+	mfs, build, err := manifestFrom(cmd)
 	cobra.CheckErr(err)
 
 	// group by Instances

--- a/cmd/cuebe/cmd/eval.go
+++ b/cmd/cuebe/cmd/eval.go
@@ -1,0 +1,93 @@
+/*
+Copyright © 2021 Loft Orbital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+    "github.com/loft-orbital/cuebe/cmd/cuebe/factory"
+	"github.com/spf13/cobra"
+	"fmt"
+// 	"cuelang.org/go/cue"
+	"github.com/loft-orbital/cuebe/pkg/build"
+	"cuelang.org/go/cue/load"
+// 	"cuelang.org/go/cue/cuecontext"
+//     "cuelang.org/go/cue/format"
+// 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func newEvalCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:        "eval",
+		SuggestFor: []string{"render", "template"},
+		Short:      "Equivalent of cue eval command.",
+		Long: `
+Will evaluate the cue definition without requiring concrete values and produce a JSON output
+the same as 'cue eval' would do.
+		`,
+		Example: `
+# Export current directory
+cuebe eval .
+`,
+		Run: runEval,
+	}
+
+	factory.BuildAware(cmd)
+	factory.BuildContextAware(cmd)
+
+	return cmd
+}
+
+func runEval(cmd *cobra.Command, args []string) {
+// 	opts := factory.GetBuildOpt(cmd)
+//
+// 	// build
+// 	v, err := build.Build(factory.GetBuildContext(cmd), &load.Config{
+// 		Tags:    opts.Tags,
+// 		TagVars: load.DefaultTagVars(),
+// 	})
+// 	if err != nil {
+// 		return nil, cue.Value{}, fmt.Errorf("could not build context: %w", err)
+// 	}
+//
+// 	// parse paths
+// 	paths := make([]cue.Path, 0, len(opts.Expressions))
+// 	for _, e := range opts.Expressions {
+// 		p := cue.ParsePath(e)
+// 		fmt.Printf("%q", p)
+// 		if p.Err() != nil {
+// 			return nil, v, fmt.Errorf("failed to parse expression %s: %w", e, p.Err())
+// 		}
+// 		paths = append(paths, p)
+// 	}
+
+    evalFrom(cmd)
+}
+
+func evalFrom(cmd *cobra.Command) { //([]manifest.Manifest, cue.Value, error) {
+    opts := factory.GetBuildOpt(cmd)
+
+    // build the cuebe context
+    v, err := build.Build(factory.GetBuildContext(cmd), &load.Config{
+        Tags:    opts.Tags,
+        TagVars: load.DefaultTagVars(),
+    })
+    if err != nil {
+        fmt.Errorf("could not build context: %w", err)
+    }
+
+    // print the value
+    fmt.Printf("// %%v\n%v\n\n// %%# v\n%# v\n", v, v)
+    fmt.Println("End of pouet")
+}

--- a/cmd/cuebe/cmd/eval.go
+++ b/cmd/cuebe/cmd/eval.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 package cmd
 
 import (
-    "github.com/loft-orbital/cuebe/cmd/cuebe/factory"
-	"github.com/spf13/cobra"
-	"fmt"
 	"cuelang.org/go/cue"
-	"github.com/loft-orbital/cuebe/pkg/build"
 	"cuelang.org/go/cue/load"
+	"fmt"
+	"github.com/loft-orbital/cuebe/cmd/cuebe/factory"
+	"github.com/loft-orbital/cuebe/pkg/build"
+	"github.com/spf13/cobra"
 )
 
 func newEvalCmd() *cobra.Command {
@@ -47,36 +47,36 @@ cuebe eval .
 }
 
 func runEval(cmd *cobra.Command, args []string) {
-    // Build opts, shall return a BuildOpt{} struct
-    opts := factory.GetBuildOpt(cmd)
+	// Build opts, shall return a BuildOpt{} struct
+	opts := factory.GetBuildOpt(cmd)
 
-    // build the cuebe context, and return a cue.Value with the unified cue structure
-    v, err := build.Build(factory.GetBuildContext(cmd), &load.Config{
-        Tags:    opts.Tags,
-        TagVars: load.DefaultTagVars(),
-    })
-    if err != nil {
-        fmt.Errorf("could not build context: %w", err)
-    }
+	// build the cuebe context, and return a cue.Value with the unified cue structure
+	v, err := build.Build(factory.GetBuildContext(cmd), &load.Config{
+		Tags:    opts.Tags,
+		TagVars: load.DefaultTagVars(),
+	})
+	if err != nil {
+		fmt.Errorf("could not build context: %w", err)
+	}
 
-    // Parse paths expressions (-e argument)
-    paths := make([]cue.Path, 0, len(opts.Expressions))
-    for _, e := range opts.Expressions {
-        p := cue.ParsePath(e)
-        if p.Err() != nil {
-            fmt.Errorf("failed to parse expression %s: %w", e, p.Err())
-        }
-        paths = append(paths, p)
-    }
+	// Parse paths expressions (-e argument)
+	paths := make([]cue.Path, 0, len(opts.Expressions))
+	for _, e := range opts.Expressions {
+		p := cue.ParsePath(e)
+		if p.Err() != nil {
+			fmt.Errorf("failed to parse expression %s: %w", e, p.Err())
+		}
+		paths = append(paths, p)
+	}
 
-    // Output the cue evaluation WITHOUT concrete values
-    // If we have no paths, we dump the whole unified values
-    if len(paths) == 0 {
-        fmt.Printf("%v", v)
-    } else {
-        for _, p := range paths {
-            node := v.LookupPath(p)
-            fmt.Printf("%v", node)
-        }
-    }
+	// Output the cue evaluation WITHOUT concrete values
+	// If we have no paths, we dump the whole unified values
+	if len(paths) == 0 {
+		fmt.Printf("%v", v)
+	} else {
+		for _, p := range paths {
+			node := v.LookupPath(p)
+			fmt.Printf("%v", node)
+		}
+	}
 }

--- a/cmd/cuebe/cmd/eval.go
+++ b/cmd/cuebe/cmd/eval.go
@@ -46,6 +46,7 @@ cuebe eval .
 	return cmd
 }
 
+// TODO: Rely on Cobra err catching system
 func runEval(cmd *cobra.Command, args []string) {
 	// Build opts, shall return a BuildOpt{} struct
 	opts := factory.GetBuildOpt(cmd)
@@ -56,15 +57,21 @@ func runEval(cmd *cobra.Command, args []string) {
 		TagVars: load.DefaultTagVars(),
 	})
 	if err != nil {
-		fmt.Errorf("could not build context: %w", err)
+		cobra.CheckErr(fmt.Errorf("could not build context: %w", err))
 	}
+
+	// // test validate
+	// // Add concrete flag here
+	// if err = v.Validate(cue.Concrete(true)); err != nil {
+	// 	cobra.CheckErr(fmt.Errorf("validation error: %v", err))
+	// }
 
 	// Parse paths expressions (-e argument)
 	paths := make([]cue.Path, 0, len(opts.Expressions))
 	for _, e := range opts.Expressions {
 		p := cue.ParsePath(e)
 		if p.Err() != nil {
-			fmt.Errorf("failed to parse expression %s: %w", e, p.Err())
+			cobra.CheckErr(fmt.Errorf("failed to parse expression %s: %w", e, p.Err()))
 		}
 		paths = append(paths, p)
 	}

--- a/cmd/cuebe/cmd/export.go
+++ b/cmd/cuebe/cmd/export.go
@@ -44,7 +44,7 @@ cuebe export -i main.enc.yaml
 }
 
 func runExport(cmd *cobra.Command, args []string) {
-	mfs, _, err := manifetsFrom(cmd)
+	mfs, _, err := manifestFrom(cmd)
 	cobra.CheckErr(err)
 
 	// render

--- a/cmd/cuebe/cmd/root.go
+++ b/cmd/cuebe/cmd/root.go
@@ -56,6 +56,7 @@ func init() {
 		newApplyCmd(),
 		newDeleteCmd(),
 		newExportCmd(),
+		newEvalCmd(),
 		newInstallCmd(),
 		newPackCmd(),
 		newVersionCmd(),


### PR DESCRIPTION
Add a new subcommand: `eval`

Should help troubleshooting errors like "manifest not found" and help inspect the cue definitions better